### PR TITLE
fix(RegistrationView): fix validation of the city field

### DIFF
--- a/src/view/RegistrationView/data.ts
+++ b/src/view/RegistrationView/data.ts
@@ -19,7 +19,7 @@ const ErrorMessages = {
 const RegExps = {
   EMAIL: /^\S+@\S+\.\S+$/,
   LETTERS: /^[^\W\d_]+$/,
-  WORDS: /^[\w ]+$/,
+  WORDS: /^[A-Za-z ]+$/,
   DATE: /^[0-9]{1,2}\/[0-9]{1,2}\/[0-9]{4,}$/,
   STREET: /^.+$/,
   MIN_LENGTH: /.{8,}/,
@@ -28,7 +28,6 @@ const RegExps = {
   ONE_DIGIT: /\d/,
   ONE_SPECIAL: /[!@#$%^&*]/,
   NO_EDGE_WHITESPACE: /^(?!\s).*(?<!\s)$/,
-  NO_UNDERSCORE: /^[^_]+$/,
   AT_SYMBOL: /@/,
   DOMAIN: /@[^\s@]+\.[^\s@]+/,
   ONE_SYMBOL: /.+/,
@@ -82,7 +81,6 @@ export const ValidationData: Record<string, PatternAndMessage[]> = {
   CITY: [
     [RegExps.ONE_SYMBOL, ErrorMessages.ONE_SYMBOL],
     [RegExps.NO_EDGE_WHITESPACE, ErrorMessages.NO_EDGE_WHITESPACE],
-    [RegExps.NO_UNDERSCORE, ErrorMessages.WORDS],
     [RegExps.WORDS, ErrorMessages.WORDS],
   ],
   POSTAL_CODES: [[RegExps.NO_EDGE_WHITESPACE, ErrorMessages.NO_EDGE_WHITESPACE]],


### PR DESCRIPTION
Task: N/A
Task code: N/A
Trello ticket: [link](https://trello.com/c/2mCPu1c0/107-reg-page-city-field-hotfix)
Description of the change: fixed checking of the "City" field in the registration form. Now it can only accept Latin letters and a space.