### PR TITLE
Send the date of birth to the server during registration

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,7 @@ export interface CustomerCredentials {
   firstName: string;
   lastName: string;
   password: string;
+  dateOfBirth: string;
   addresses: Address[];
   shippingAddresses: number[];
   billingAddresses: number[];

--- a/src/view/RegistrationView/UserInfoView/UserInfoView.ts
+++ b/src/view/RegistrationView/UserInfoView/UserInfoView.ts
@@ -6,6 +6,7 @@ import { UserInfoCredentials } from '../types';
 import { UserInfoInputsOptions, DataAttrs } from '../data';
 
 const BIRTH_DATE_INPUT_INDEX = 4;
+const DATE_SEPARATOR = '/';
 
 export default class UserInfoView {
   private view = Converter.htmlToElement<HTMLDivElement>(HTML) || document.createElement('div');
@@ -32,6 +33,7 @@ export default class UserInfoView {
       password: '',
       firstName: '',
       lastName: '',
+      dateOfBirth: '',
     };
 
     const inputs = this.view.querySelectorAll('input');
@@ -49,6 +51,10 @@ export default class UserInfoView {
       }
       if (inputType === 'last-name') {
         credentials.lastName = input.value;
+      }
+      if (inputType === 'birth-date') {
+        const [month, day, year] = input.value.split(DATE_SEPARATOR);
+        credentials.dateOfBirth = `${year}-${month}-${day}`;
       }
     });
 

--- a/src/view/RegistrationView/types.ts
+++ b/src/view/RegistrationView/types.ts
@@ -13,6 +13,7 @@ export interface UserInfoCredentials {
   firstName: string;
   lastName: string;
   password: string;
+  dateOfBirth: string;
 }
 
 export type PatternAndMessage = [RegExp, string];


### PR DESCRIPTION
**Task**: N/A
**Task code**: N/A
**Trello ticket**: [link](https://trello.com/c/gVcRm5lh/111-feature-reg-page-take-into-account-the-date-of-birth)
**Description of the change**: added sending data about the user's date of birth to the server during registration

**Type**:
- [x] Feature
- [ ] Bug
- [ ] Refactor
- [ ] Infrastructure

**Acceptance criteria checklist**:
- [x] The user's date of birth is saved on the server (you can check it in Commercetools)

**Tests**:
- [ ] put test filenames here
- [ ] covered already
- [x] not required
- [ ] N/A

**Checklist**:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes