### PR TITLE
Fix product details view for products with only one picture

### DIFF
--- a/src/view/ProductView/ProductView.ts
+++ b/src/view/ProductView/ProductView.ts
@@ -26,7 +26,11 @@ const sliderClickDelay = 1200;
 export default class ProductView {
   private static activeImage: number = 0;
 
-  private lastTimeClick: number = Date.now();
+  private lastTimeClick: number;
+
+  constructor() {
+    this.lastTimeClick = Date.now();
+  }
 
   public draw(id: string): void {
     const main: HTMLElement = document.querySelector('main')!;
@@ -113,13 +117,15 @@ export default class ProductView {
     const leftButton = document.querySelector(`#${SliderSelectors.SLIDER_MAIN_LEFT}`) as HTMLElement;
     const rightButton = document.querySelector(`#${SliderSelectors.SLIDER_MAIN_RIGHT}`) as HTMLElement;
 
-    leftButton.addEventListener('click', () => {
-      this.lastTimeClick = Date.now();
-    });
+    if (leftButton && rightButton) {
+      leftButton.addEventListener('click', () => {
+        this.lastTimeClick = Date.now();
+      });
 
-    rightButton.addEventListener('click', () => {
-      this.lastTimeClick = Date.now();
-    });
+      rightButton.addEventListener('click', () => {
+        this.lastTimeClick = Date.now();
+      });
+    }
   }
 
   private widenDescription(): void {


### PR DESCRIPTION
**Task**: N/A
**Task code**: N/A
**Trello ticket**: [link](https://trello.com/c/BcPbfLgQ/154-bug-single-picture-product-is-not-displayed)
**Description of the change**: fixed an error with missing product details page for products with only one picture

**Type**:
- [ ] Feature
- [x] Bug
- [ ] Refactor
- [ ] Infrastructure

**Acceptance criteria checklist**:
- [x] single picture product details page is displayed correctly

**Tests**:
- [ ] put test filenames here
- [ ] covered already
- [x] not required
- [ ] N/A

**Checklist**:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes