### PR TITLE
Fix adding new addresses error

### DIFF
--- a/src/view/ProfileView/AddressesView/AddressesView.ts
+++ b/src/view/ProfileView/AddressesView/AddressesView.ts
@@ -119,6 +119,11 @@ export default abstract class AddressesView {
       this.configureList(response, defaultId);
       this.colorAddresses();
     }
+
+    if (!response[defaultId]) {
+      this.originalDefaultAddress = new AddressView();
+      this.prevDefaultAddress = new AddressView();
+    }
   }
 
   private updateAddresses(addresses: AddressView[]): void {


### PR DESCRIPTION
**Task**: N/A
**Task code**: N/A
**Trello ticket**: [link](https://trello.com/c/o6V4Ov88/155-bug-user-profile-add-address-after-deleting-default-address)
**Description of the change**: now, after deleting the default address, you can add a new one without reloading the page

**Type**:
- [ ] Feature
- [x] Bug
- [ ] Refactor
- [ ] Infrastructure

**Acceptance criteria checklist**:
- [x] The user can add a new address after deleting the default address without reloading the page.

**Tests**:
- [ ] put test filenames here
- [ ] covered already
- [x] not required
- [ ] N/A

**Checklist**:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes