### PR TITLE
fix: add warning if item in cart and process network error

### DIFF
--- a/src/view/ProductView/ProductView.html
+++ b/src/view/ProductView/ProductView.html
@@ -53,6 +53,7 @@
               </svg>
               Add to cart
             </button>
+            <div class="p-2 font-bold text-red-600 bg-red-200 mb-2 hidden" id="in-cart">In the cart already</div>
             <button
               class="px-6 pt-3 pb-3 w-48 rounded-lg font-medium text-center text-white transition-colors duration-300 bg-blue-900 hover:bg-blue-400 hidden"
               id="remove-button"

--- a/src/view/ProductView/ProductView.ts
+++ b/src/view/ProductView/ProductView.ts
@@ -103,17 +103,21 @@ export default class ProductView {
   private disableAddToCart(): void {
     const addToCartButton = document.querySelector(`#${ProductElements.PRODUCT_ADD}`) as HTMLButtonElement;
     const removeFromCartButton = document.querySelector(`#${ProductElements.PRODUCT_REMOVE}`) as HTMLButtonElement;
+    const inCartText = document.querySelector(`#${ProductElements.PRODUCT_IN_CART}`) as HTMLButtonElement;
 
     addToCartButton.classList.add('hidden');
 
     removeFromCartButton.classList.remove('hidden');
+    inCartText.classList.remove('hidden');
   }
 
   private disableRemoveFromCart(): void {
     const addToCartButton = document.querySelector(`#${ProductElements.PRODUCT_ADD}`) as HTMLButtonElement;
     const removeFromCartButton = document.querySelector(`#${ProductElements.PRODUCT_REMOVE}`) as HTMLButtonElement;
+    const inCartText = document.querySelector(`#${ProductElements.PRODUCT_IN_CART}`) as HTMLButtonElement;
 
     removeFromCartButton.classList.add('hidden');
+    inCartText.classList.add('hidden');
 
     addToCartButton.classList.remove('hidden');
   }
@@ -224,9 +228,9 @@ export default class ProductView {
         } else {
           cart.setProductAmount(0);
         }
-      } else {
-        this.showMessage(document.querySelector(`#${ProductElements.PRODUCT_NETWORK_ERROR}`) as HTMLElement);
       }
+    } else {
+      this.showMessage(document.querySelector(`#${ProductElements.PRODUCT_NETWORK_ERROR}`) as HTMLElement);
     }
   }
 

--- a/src/view/ProductView/data.ts
+++ b/src/view/ProductView/data.ts
@@ -30,6 +30,7 @@ enum ProductElements {
   PRODUCT_PLEASE_LOGIN = 'please-login',
   PRODUCT_BUTTON_BLOCK = 'button-block',
   PRODUCT_OUT_OF_STOCK = 'out-of-stock',
+  PRODUCT_IN_CART = 'in-cart',
 }
 
 const categoryStyles = ['border-solid', 'rounded-full', 'border-2', 'px-3', 'text-center', 'self-center'];


### PR DESCRIPTION
**Task**: N/A
**Task code**: N/A
**Trello ticket**: [link](https://trello.com/c/QnQy8QiG/165-bug-a-notice-if-a-car-is-in-cart-already-and-its-error-handling)
**Description of the change**: Two changes: 1. Add a warning on product page if the product is in the cart already. 2. Process network error on the 'Add to cart' click

**Type**:
- [ ] Feature
- [x] Bug
- [ ] Refactor
- [ ] Infrastructure

**Acceptance criteria checklist**:
- [x] If a car is in the cart then a user can see a relevant notice on the Product page
- [x] If we click the 'Add to cart' button and we have no Internet, then network error is shown

**Tests**:
- [ ] covered already
- [ ] not required
- [x] N/A

**Checklist**:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes